### PR TITLE
Use latest PlantUML jar file to download [1.2021.4]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,8 @@ FROM python:3.8-alpine
 
 RUN apk update && apk --no-cache add gcc musl-dev openjdk11-jdk curl graphviz ttf-dejavu fontconfig
 
-# Download plantuml file
-RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2021.4.jar/download
-
-# Validate checksum
-RUN echo "be498123d20eaea95a94b174d770ef94adfdca18  plantuml.jar" | sha1sum -c -
-
-# Move plantuml file
-RUN mv plantuml.jar /opt/plantuml.jar
+# Download plantuml file, Validate checksum & Move plantuml file
+RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2021.4.jar/download && echo "be498123d20eaea95a94b174d770ef94adfdca18  plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
 
 RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==0.0.16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,15 @@ RUN apk update && apk --no-cache add gcc musl-dev openjdk11-jdk curl graphviz tt
 # Download plantuml file
 RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2021.4.jar/download
 
-# Create script to call plantuml.jar from a location in path
+# Validate checksum
+RUN echo "be498123d20eaea95a94b174d770ef94adfdca18  plantuml.jar" | sha1sum -c -
 
+# Move plantuml file
+RUN mv plantuml.jar /opt/plantuml.jar
+
+RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==0.0.16
+
+# Create script to call plantuml.jar from a location in path
 RUN echo $'#!/bin/sh\n\njava -jar '/opt/plantuml.jar' ${@}' >> /usr/local/bin/plantuml
 RUN chmod 755 /usr/local/bin/plantuml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ FROM python:3.8-alpine
 
 RUN apk update && apk --no-cache add gcc musl-dev openjdk11-jdk curl graphviz ttf-dejavu fontconfig
 
-RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2020.16.jar/download && echo "c789ace48347c43073232b1458badc5810c01fe8  plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
-RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==0.0.15
+# Download plantuml file
+RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2021.4.jar/download
 
 # Create script to call plantuml.jar from a location in path
 


### PR DESCRIPTION
Some usage of PlantUML (C4 diagrams for example) were broken because we use a very old version of the jar file we download. This upgrades that to the latest one and fix the parsing issues.

**Before**
<img width="829" alt="Screen Shot 2021-04-19 at 2 06 21 PM" src="https://user-images.githubusercontent.com/25153114/115240479-1186bb80-a120-11eb-9264-6d5487f40b01.png">

**After**
<img width="754" alt="Screen Shot 2021-04-19 at 2 07 21 PM" src="https://user-images.githubusercontent.com/25153114/115240490-13e91580-a120-11eb-999e-d9d24dabc6b9.png">
