### PR TITLE
Bump mkdocs-techdocs-core version to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk update && apk --no-cache add gcc musl-dev openjdk11-jdk curl graphviz tt
 # Download plantuml file, Validate checksum & Move plantuml file
 RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2021.4.jar/download && echo "be498123d20eaea95a94b174d770ef94adfdca18  plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
 
-RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==0.0.16
+RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==0.1.0
 
 # Create script to call plantuml.jar from a location in path
 RUN echo $'#!/bin/sh\n\njava -jar '/opt/plantuml.jar' ${@}' >> /usr/local/bin/plantuml


### PR DESCRIPTION
Follow-up to backstage/mkdocs-techdocs-core#27 that packages the improvements into the container.  Improvements come from an update to mkdocs v1.2.2, including...

- Both `mkdocs.yml` and `mkdocs.yaml` are allowed.
- More improvements, see [mkdocs release notes](https://www.mkdocs.org/about/release-notes/#version-122-2021-07-18)

Related to backstage/backstage#3660