### PR TITLE
bump mkdocs-techdocs-core package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk update && apk --no-cache add gcc musl-dev openjdk11-jdk curl graphviz tt
 # Download plantuml file, Validate checksum & Move plantuml file
 RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2021.4.jar/download && echo "be498123d20eaea95a94b174d770ef94adfdca18  plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
 
-RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==0.1.2
+RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==0.2.0
 
 # Create script to call plantuml.jar from a location in path
 #   When adding TechDocs to the Backstage Backend container, avoid this

--- a/mock-docs/docs/index.md
+++ b/mock-docs/docs/index.md
@@ -59,7 +59,19 @@ digraph G {
 @enduml
 ```
 
-:bulb:
+# Emojis
+
+:bulb: :smile:
+
+# Code blocks
+
+```javascript
+import { test } from 'something';
+
+const addThingToThing = (a, b) a + b;
+```
+
+# Grouped Code blocks
 
 === "JavaScript"
 
@@ -87,12 +99,6 @@ digraph G {
     public void function() {
       test();
     }
-```
-
-```javascript
-import { test } from 'something';
-
-const addThingToThing = (a, b) a + b;
 ```
 
 <!-- prettier-ignore -->

--- a/mock-docs/docs/index.md
+++ b/mock-docs/docs/index.md
@@ -101,5 +101,22 @@ const addThingToThing = (a, b) a + b;
     }
 ```
 
+# MDX truly sane lists
+
+- attributes
+
+- customer
+  - first_name
+    - test
+  - family_name
+  - email
+- person
+  - first_name
+  - family_name
+  - birth_date
+- subscription_id
+
+- request
+
 <!-- prettier-ignore -->
 *[MOCDOC]: Mock Documentation


### PR DESCRIPTION
The [latest version (0.2.0)](https://github.com/backstage/mkdocs-techdocs-core#020) of [mkdocs-techdocs-core](https://pypi.org/project/mkdocs-techdocs-core/0.2.0/) introduces a new mkdocs extension `mdx_truly_sane_lists` for dealing with the bullet differences in mkdocs vs commonmark / gf markdown. 

This PR upgrades the mkdocs-techdocs-core version to the latest version including the new extension.

Ref: https://github.com/backstage/backstage/issues/6057#issuecomment-862822002 


**Before**
<img width="785" alt="Screen Shot 2021-10-05 at 10 01 54 AM" src="https://user-images.githubusercontent.com/25153114/135984749-0c8cf52b-8b08-45be-bd62-77bfb5715234.png">

**After**
<img width="809" alt="Screen Shot 2021-10-05 at 9 59 43 AM" src="https://user-images.githubusercontent.com/25153114/135984742-e4b39ace-fc5b-4458-bd3e-d483523b60b2.png">

