### PR TITLE
Bump TechDocs Core plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk update && apk --no-cache add gcc musl-dev openjdk11-jdk curl graphviz tt
 # Download plantuml file, Validate checksum & Move plantuml file
 RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2021.12.jar/download && echo "a3d10c17ab1158843a7a7120dd064ba2eda4363f  plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
 
-RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==0.2.0
+RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==0.2.1
 
 # Create script to call plantuml.jar from a location in path
 #   When adding TechDocs to the Backstage Backend container, avoid this


### PR DESCRIPTION
Includes two improvements to monorepos:

- Added support for `.yaml` file extension support on `mkdocs.y(a)ml` in monorepo contexts [[backstage/mkdocs-monorepo-plugin#59](https://github.com/backstage/mkdocs-monorepo-plugin/pull/59)]
- Added the ability for `site_name`s in `!include`'d mkdocs sites to contain non-URL friendly characters [[backstage/mkdocs-monorepo-plugin#58](https://github.com/backstage/mkdocs-monorepo-plugin/pull/55)]