### PR TITLE
Adding Mermaid Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,17 +17,9 @@ FROM python:3.8-alpine
 
 RUN apk update && apk --no-cache add gcc musl-dev openjdk11-jdk curl graphviz ttf-dejavu fontconfig
 
-# Download plantuml file, Validate checksum & Move plantuml file
-RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2021.12.jar/download && echo "a3d10c17ab1158843a7a7120dd064ba2eda4363f  plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
-
 RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==0.2.1
 
-# Create script to call plantuml.jar from a location in path
-#   When adding TechDocs to the Backstage Backend container, avoid this
-#   error (OSError: [Errno 8] Exec format error: 'plantuml') by using the
-#   following RUN command instead:
-#   RUN echo '#!/bin/sh\n\njava -jar '/opt/plantuml.jar' ${@}' >> /usr/local/bin/plantuml
-RUN echo $'#!/bin/sh\n\njava -jar '/opt/plantuml.jar' ${@}' >> /usr/local/bin/plantuml
-RUN chmod 755 /usr/local/bin/plantuml
+#Installing kroki to support different diagrams
+RUN pip install mkdocs-kroki-plugin
 
 ENTRYPOINT [ "mkdocs" ]

--- a/mock-docs/docs/index.md
+++ b/mock-docs/docs/index.md
@@ -59,6 +59,16 @@ digraph G {
 @enduml
 ```
 
+# Mermaid Samples
+
+```kroki-mermaid
+sequenceDiagram
+GitLab->>Kroki: Request rendering
+Kroki->>Mermaid: Request rendering
+Mermaid-->>Kroki: Image
+Kroki-->>GitLab: Image
+```
+
 # Emojis
 
 :bulb: :smile:

--- a/mock-docs/mkdocs.yml
+++ b/mock-docs/mkdocs.yml
@@ -7,3 +7,4 @@ nav:
 
 plugins:
   - techdocs-core
+  - kroki


### PR DESCRIPTION
[Kroki](https://kroki.io/examples.html) creates diagram from Textual description . It is a single rendering gateway for all popular diagrams-as-a-code tools. It supports an enormous number of diagram types including Plantuml.

Approach: Mkdocs has a plugin for kroki that we can install using pip. So we did changes in our techdoc docker image to install kroki in our container.

Changes :

- **Dockerfile:** removed plantuml section as kroki supports plantuml diagram
- **mkdocs.yml:** as we need to specify the kroki plugin in it.
- **index.md:** how to write the code to render diagrams.

Other diagrams kroki supports :
![image](https://user-images.githubusercontent.com/31981299/148246963-67fae7f9-99bb-419c-8a5d-d9450f515323.png)
