### PR TITLE
Add example of a wildcard monorepo include

### DIFF
--- a/mock-docs/mkdocs.yml
+++ b/mock-docs/mkdocs.yml
@@ -4,6 +4,7 @@ site_description: 'mock-docs site description'
 nav:
   - Home: index.md
   - SubDocs: '!include ./sub-docs/mkdocs.yml'
+  - Plugins: '*include ./plugins/*/mkdocs.yml'
 
 plugins:
   - techdocs-core

--- a/mock-docs/plugins/plugin-a/docs/index.md
+++ b/mock-docs/plugins/plugin-a/docs/index.md
@@ -1,0 +1,4 @@
+# Plugin A
+
+This is a description of Plugin A. This file exists to prove that glob'd
+includes using the `*include` syntax work as expected.

--- a/mock-docs/plugins/plugin-a/mkdocs.yml
+++ b/mock-docs/plugins/plugin-a/mkdocs.yml
@@ -1,0 +1,5 @@
+site_name: Plugin A
+site_description: A description of Plugin A
+
+nav:
+  - Introduction: index.md

--- a/mock-docs/plugins/plugin-b/docs/index.md
+++ b/mock-docs/plugins/plugin-b/docs/index.md
@@ -1,0 +1,4 @@
+# Plugin B
+
+This is a description of Plugin B. This file exists to prove that glob'd
+includes using the `*include` syntax work as expected.

--- a/mock-docs/plugins/plugin-b/mkdocs.yml
+++ b/mock-docs/plugins/plugin-b/mkdocs.yml
@@ -1,0 +1,5 @@
+site_name: Plugin B
+site_description: A description of Plugin B
+
+nav:
+  - Introduction: index.md


### PR DESCRIPTION
Just adding an example of the wildcard include.

FYI: Once merged, I will also use this as an opportunity to release `v0.3.6` of the container.  There is no need to bump `mkdocs-techdocs-core` because it has a looser constraint on `mkdocs-monorepo` (`~0.5.1`).  The act of releasing will re-trigger a build/publish of the current docker image, which will see the latest `mkdocs-monorepo` included.