### PR TITLE
Bump techdocs-core version to 1.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk update && apk --no-cache add gcc musl-dev openjdk11-jdk curl graphviz tt
 # Download plantuml file, Validate checksum & Move plantuml file
 RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2022.4.jar/download && echo "246d1ed561ebbcac14b2798b45712a9d018024c0  plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
 
-RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==1.0.1
+RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==1.0.2
 
 # Create script to call plantuml.jar from a location in path
 #   When adding TechDocs to the Backstage Backend container, avoid this


### PR DESCRIPTION
Follow-up to https://github.com/backstage/mkdocs-techdocs-core/pull/59, incorporating the underlying change into the container.

This will add language-specific class names to codeblocks in generated documentation, allowing Addons to more easily target them (e.g. to support mermaid diagrams)