### PR TITLE
Adding minify plugin support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk update && apk --no-cache add gcc musl-dev openjdk11-jdk curl graphviz tt
 # Download plantuml file, Validate checksum & Move plantuml file
 RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2022.4.jar/download && echo "246d1ed561ebbcac14b2798b45712a9d018024c0  plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
 
-RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==1.0.2
+RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==1.0.2 mkdocs-minify-plugin==0.5.0
 
 # Create script to call plantuml.jar from a location in path
 #   When adding TechDocs to the Backstage Backend container, avoid this


### PR DESCRIPTION
I am curious how we could allow other plugins to be enabled before running container?  Perhaps we allow or create an entry point that allows running install on a requirements.txt before mkdocs target?