### PR TITLE
chore(deps): Update dependency mkdocs-techdocs-core to v1.1.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apk update && apk --no-cache add gcc musl-dev openjdk17-jdk curl graphviz tt
 # Download plantuml file, Validate checksum & Move plantuml file
 RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2022.4.jar/download && echo "246d1ed561ebbcac14b2798b45712a9d018024c0  plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
 
-RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==1.1.4
+RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==1.1.7
 
 # Create script to call plantuml.jar from a location in path
 #   When adding TechDocs to the Backstage Backend container, avoid this


### PR DESCRIPTION
Updates to the latest version of `mkdocs-techdocs-core`.  This latest version includes an update to `mkdocs-monorepo-plugin`, which was not previously compatible with `mkdocs` v1.4.0.