### PR TITLE
Update release-tag.yml

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }} # This is not the actual password of the user, just a token
@@ -27,8 +27,9 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: spotify/techdocs:${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
Trying to make dockerhub publishing work with inspiration from this example: https://docs.docker.com/build/ci/github-actions/multi-platform/

* Set `with.context: .`
* bump step versions

It fails with the following error
```
insufficient_scope: authorization failed
```
Which led me to this thread: https://github.com/docker/build-push-action/issues/160