### PR TITLE
update github action workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       # Build Docker Image
       - name: Build Docker image
-        uses: docker/build-push-action@v1.1.0
+        uses: docker/build-push-action@v4
         with:
           path: .
           push: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,22 +10,26 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }} # This is not the actual password of the user, just a token
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
+          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: spotify/techdocs:latest


### PR DESCRIPTION
I started changing the workflow files to make pushing to dockerhub work again, resulting in these PR:s

* #49 
* #51 

**However**, the actual problem was that the credentials to the dockerhub organization had been rotated. That's fixed now.

Now that the publishing works, I created this PR to update the remaining files to use the latest and greatest actions. Also merging this will publish the `latest` tag which has been failing since the latest release.