### PR TITLE
chore: add kroki plugin to allow for mermaid diagrams

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ RUN apk update && apk --no-cache add gcc musl-dev openjdk17-jdk curl graphviz tt
 # Download plantuml file, Validate checksum & Move plantuml file
 RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2022.4.jar/download && echo "246d1ed561ebbcac14b2798b45712a9d018024c0  plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
 
-RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==1.2.1
+ARG MKDOCS_VERSION=1.2.1
+ARG MKDOCS_KROKI_PLUGIN_VERSION=0.6.1
+RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==${MKDOCS_VERSION} mkdoc-kroki-plugin==${MKDOCS_KROKI_PLUGIN_VERSION}
 
 # Create script to call plantuml.jar from a location in path
 #   When adding TechDocs to the Backstage Backend container, avoid this


### PR DESCRIPTION
Based on [these docs](https://backstage.io/docs/features/techdocs/how-to-guides/#how-to-add-mermaid-support-in-techdocs) this updates the Docker image to include the kroki plugin to allow for [mermaid diagrams](https://squidfunk.github.io/mkdocs-material/reference/diagrams/)