### PR TITLE
Updated PlantUML version and DL source.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM python:3.8-alpine
 RUN apk update && apk --no-cache add gcc musl-dev openjdk17-jdk curl graphviz ttf-dejavu fontconfig
 
 # Download plantuml file, Validate checksum & Move plantuml file
-RUN curl -o plantuml.jar -L http://sourceforge.net/projects/plantuml/files/plantuml.1.2022.4.jar/download && echo "246d1ed561ebbcac14b2798b45712a9d018024c0  plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
+RUN curl -o plantuml.jar -L https://github.com/plantuml/plantuml/releases/download/v1.2023.10/plantuml-1.2023.10.jar && echo "527d28af080ae91a455e7023e1a726c7714dc98e plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
 
 RUN pip install --upgrade pip && pip install mkdocs-techdocs-core==1.2.2
 


### PR DESCRIPTION
Bumps the version of PlantUML to the (current) latest version.

- Also addresses potential security hole by pointing to GitHub source, vs the SourceForge source.

See:

- https://github.com/backstage/techdocs-container/pull/56
- https://github.com/backstage/techdocs-container/issues/46