### PR TITLE
add stale issue and pr workflow

### DIFF
--- a/.github/workflows/automate_stale.yml
+++ b/.github/workflows/automate_stale.yml
@@ -1,0 +1,31 @@
+name: Close Stale Issues and PRs Automatically
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '*/10 * * * *' # run every 10 minutes as it also removes labels.
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4.1.1
+        id: stale
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank you
+            for your contributions.
+          days-before-issue-stale: 60
+          days-before-issue-close: 7
+          exempt-issue-labels: after-vacations,will-fix
+          stale-issue-label: stale
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not had
+            recent activity from the author. It will be closed if no further activity occurs.
+            If the PR was closed and you want it re-opened, let us know
+            and we'll re-open the PR so that you can continue the contribution!
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+          exempt-pr-labels: after-vacations,will-fix
+          stale-pr-label: stale
+          operations-per-run: 

--- a/.github/workflows/automate_stale.yml
+++ b/.github/workflows/automate_stale.yml
@@ -28,4 +28,4 @@ jobs:
           days-before-pr-close: 7
           exempt-pr-labels: after-vacations,will-fix
           stale-pr-label: stale
-          operations-per-run: 
+          operations-per-run: 100


### PR DESCRIPTION
Add a wofklow to automatically label and then close stale issues and PRs.

Mimicking the flow from [Backstage](https://github.com/backstage/backstage/blob/master/.github/workflows/automate_stale.yml) with small differences:

- Bumped the version of workflow action to the latest
- Set only two labels to be exempt from the workflow - `after-vacation` and `will-fix`. This is to either mark things as to be looked at after the vacation of the core Spotify maintainer team or to mark things as to be fixed even if the resolution is not expected to come immediately.
- Extended PR close label to 2 weeks and close time to 1 week
