### PR TITLE
Run scheduler once a day.

### DIFF
--- a/.github/workflows/automate_stale.yml
+++ b/.github/workflows/automate_stale.yml
@@ -2,7 +2,7 @@ name: Close Stale Issues and PRs Automatically
 on:
   workflow_dispatch:
   schedule:
-    - cron: '*/10 * * * *' # run every 10 minutes as it also removes labels.
+    - cron: '0 1 * * *' # run once a day as it also removes labels.
 
 jobs:
   stale:


### PR DESCRIPTION
Reduce number of runs as this only has a days- configuration so running this more than a few times a day feels really overkill.

This feels like a waste of github-action minutes or is there a good reason for running it 144 times a day?