### PR TITLE
Update Python to 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.8-alpine
+FROM python:3.12-alpine
 
 RUN apk update && apk --no-cache add gcc musl-dev openjdk17-jdk curl graphviz ttf-dejavu fontconfig
 


### PR DESCRIPTION
Thanks for making this repo, some of us are using it at Indeed.

Attempting to use the [d2](https://github.com/landmaj/mkdocs-d2-plugin) mkdoc plugin (a diagramming tool) I noticed it required the union type syntax introduced in Python 3.10. Updating the Docker image to the the latest stable Python resolved it so I figured I'd submit it upstream.