### PR TITLE
Update Python to 3.12 (latest)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.8-alpine
+FROM python:3.12-alpine
 
 RUN apk update && apk --no-cache add gcc musl-dev openjdk17-jdk curl graphviz ttf-dejavu fontconfig
 


### PR DESCRIPTION
Python 3.8 is a bit old at this point and a couple of dependencies already require Python 3.10, making the current image incompatible.

One examples is https://github.com/AVATEAM-IT-SYSTEMHAUS/mkdocs-kroki-plugin/blob/main/setup.py#L20, which my employer uses internally and thus we need a Python version update to be able to use the latest version of that plugin.