### PR TITLE
build: Use PlantUML from Docker image to work with Renovate, remove pip cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY --from=plantuml/plantuml:1.2026.2@sha256:711a0cdf56a46d9bfac8fcc4c08872cd47
     /opt/plantuml.jar /opt/plantuml.jar
 
 COPY requirements.txt .
-RUN pip install --upgrade pip && pip install -r requirements.txt
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
 # Create script to call plantuml.jar from a location in path
 #   printf is what avoids this error (OSError: [Errno 8] Exec format error: 'plantuml')

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,14 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -r requirements.txt
 
 # Create script to call plantuml.jar from a location in path
-#   printf is what avoids this error (OSError: [Errno 8] Exec format error: 'plantuml')
-#   when adding TechDocs to the Backstage Backend container: shells without $'' support,
-#   eg. dash, write a literal `$` into the shebang from `echo $'...'`.
-
 #   When adding TechDocs with PlantUML diagrams, to refer external puml or pu files in any markdown file,
 #   eg. '!include <referencedFileName.puml>', you'll need to include the diagrams directory eg. docs in the classpath.
 #   Use following RUN command instead:
 #   RUN printf '#!/bin/sh\nexec java -Dplantuml.include.path=${diagramDir} -jar /opt/plantuml.jar "$@"\n' > /usr/local/bin/plantuml && chmod 755 /usr/local/bin/plantuml
+
+#   "$@", not ${@}: unquoted, docs paths containing spaces get split into separate args.
+#   printf also copies as-is into the Backstage Backend container, where the echo form failed
+#   with: OSError: [Errno 8] Exec format error: 'plantuml'
 RUN printf '#!/bin/sh\nexec java -jar /opt/plantuml.jar "$@"\n' > /usr/local/bin/plantuml \
     && chmod 755 /usr/local/bin/plantuml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,24 +16,24 @@ FROM python:3.14-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5
 
 RUN apk update && apk --no-cache add gcc musl-dev openjdk17-jdk curl graphviz ttf-dejavu fontconfig
 
-# Download plantuml file, Validate checksum & Move plantuml file
-RUN curl -o plantuml.jar -L https://github.com/plantuml/plantuml/releases/download/v1.2026.2/plantuml-1.2026.2.jar \
-    && echo "55884e11f3f1075d4778a9ebaa9244d530a74391  plantuml.jar" | sha1sum -c - && mv plantuml.jar /opt/plantuml.jar
+# Take the plantuml jar from the official image, pinned by tag and digest so Renovate
+# keeps it updated.
+COPY --from=plantuml/plantuml:1.2026.2@sha256:711a0cdf56a46d9bfac8fcc4c08872cd47e1bd31cd87f2d0268ebe75a6b100ee \
+    /opt/plantuml.jar /opt/plantuml.jar
 
 COPY requirements.txt .
 RUN pip install --upgrade pip && pip install -r requirements.txt
 
 # Create script to call plantuml.jar from a location in path
-#   When adding TechDocs to the Backstage Backend container, avoid this
-#   error (OSError: [Errno 8] Exec format error: 'plantuml') by using the
-#   following RUN command instead:
-#   RUN echo '#!/bin/sh\n\njava -jar '/opt/plantuml.jar' ${@}' >> /usr/local/bin/plantuml
+#   printf is what avoids this error (OSError: [Errno 8] Exec format error: 'plantuml')
+#   when adding TechDocs to the Backstage Backend container: shells without $'' support,
+#   eg. dash, write a literal `$` into the shebang from `echo $'...'`.
 
 #   When adding TechDocs with PlantUML diagrams, to refer external puml or pu files in any markdown file,
 #   eg. '!include <referencedFileName.puml>', you'll need to include the diagrams directory eg. docs in the classpath.
 #   Use following RUN command instead:
-#   RUN echo $'#!/bin/sh\n\njava -Dplantuml.include.path=${diagramDir} -jar '/opt/plantuml.jar ' ${@}' >> /usr/local/bin/plantuml
-RUN echo $'#!/bin/sh\n\njava -jar '/opt/plantuml.jar' ${@}' >> /usr/local/bin/plantuml
-RUN chmod 755 /usr/local/bin/plantuml
+#   RUN printf '#!/bin/sh\nexec java -Dplantuml.include.path=${diagramDir} -jar /opt/plantuml.jar "$@"\n' > /usr/local/bin/plantuml && chmod 755 /usr/local/bin/plantuml
+RUN printf '#!/bin/sh\nexec java -jar /opt/plantuml.jar "$@"\n' > /usr/local/bin/plantuml \
+    && chmod 755 /usr/local/bin/plantuml
 
 ENTRYPOINT [ "mkdocs" ]

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ Note: The `latest` tag on DockerHub points to the recent commits in the `main` b
 
 ## Updating PlantUML
 
-PlantUML is a Java based tool which is packaged in a single JAR file. You can find the latest released in their [GitHub repo under Releases](https://github.com/plantuml/plantuml/releases). When updating the Docker file with a new release of PlantUML you'll need to download the relevant JAR file first and then generate a checksum using `sha1sum`. Here are the steps:
+PlantUML is a Java based tool which is packaged in a single JAR file. The Dockerfile takes the JAR from the official [`plantuml/plantuml`](https://hub.docker.com/r/plantuml/plantuml) image, pinned by tag and digest, so Renovate opens the update PR and no checksum needs to be maintained by hand.
 
-1. Download the JAR file: `curl -o plantuml.jar -L https://github.com/plantuml/plantuml/releases/download/v1.2024.6/plantuml-1.2024.6.jar`
-2. Generate the checksum: `sha1sum plantuml.jar`
-3. Update the Dockerfile file with the proper release URL and checksum
+To bump it manually, update both the tag and the digest on the `COPY --from=plantuml/plantuml:...` line. Get the digest for a version with:
+
+```bash
+docker buildx imagetools inspect plantuml/plantuml:1.2026.2
+```

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
   ],
   "enabledManagers": [
     "dockerfile",
-    "pip_requirements"
+    "pip_requirements",
+    "github-actions"
   ],
   "packageRules": [
     {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-mkdocs-techdocs-core==1.7.0
+mkdocs-techdocs-core==1.7.1


### PR DESCRIPTION
Hey there, here's a few backports from our internal techdocs image setup, which should help with maintenance:

- Get the PlantUML jar from Docker instead of Github releases
  - Same file, but works with Renovate out of the box while keeping the SHA pinning (via the image digest).
- Remove ~30MB pip cache from the image
- Merge the RUN chmod 755 to have one less layer
- Enable github-actions via Renovate (noticed actions/checkout@v2 had no pin)

I've kept curl in the image to avoid breaking consumers workflows (e.g. if image is used in a CI to curl something?). Tested locally and seems fine :) 

As a follow-up, I may also backport our uv setup, to have a lockfile and thus more reproducible builds if you're interested.

Cheers!